### PR TITLE
This will add Github Actions CI and pkgdown

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,6 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$
+^\.github$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,83 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: windows-latest, r: '3.6'}
+          - {os: macOS-latest, r: '3.6'}
+          - {os: macOS-latest, r: 'devel'}
+          - {os: ubuntu-16.04, r: '3.2', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '3.3', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '3.4', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '3.5', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        if: runner.os != 'Windows'
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
+
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        env:
+          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
+        run: |
+          Rscript -e "remotes::install_github('r-hub/sysreqs')"
+          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
+          sudo -s eval "$sysreqs"
+
+      - name: Install dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+        shell: Rscript {0}
+
+      - name: Check
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,8 +21,6 @@ jobs:
           - {os: windows-latest, r: '3.6'}
           - {os: macOS-latest, r: '3.6'}
           - {os: macOS-latest, r: 'devel'}
-          - {os: ubuntu-16.04, r: '3.2', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.3', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.4', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.5', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,9 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo add-apt-repository ppa:cran/opencv
+          sudo add-apt-repository -y ppa:cran/ffmpeg-3
+          sudo apt-get update
+          sudo apt-get dist-upgrade
           sudo apt install libopencv-dev
           sudo apt install libavfilter-dev
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,6 +38,12 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@master
 
+      - name: Install linux opencv
+        if: runner.os == 'Linux'
+        run: |
+          sudo add-apt-repository ppa:opencpu/opencv
+          sudo apt install libopencv-dev
+
       - name: Query dependencies
         run: |
           install.packages('remotes')

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,8 +50,11 @@ jobs:
       - name: Install macos opencv
         if: runner.os == 'macOS'
         run: |
-          brew install opencv
-          brew install ffmpeg
+          brew install opencv ffmpeg imagemagick@6
+
+      - name: Install xml2 from github (for devel only \#296)
+        if: matrix.config.os == 'macOS-latest' && needs.R-CMD-check-bioc.outputs.rversion == 'devel'
+        run: Rscript -e "remotes::install_github('r-lib/xml2')"
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,15 +52,15 @@ jobs:
         run: |
           brew install opencv ffmpeg imagemagick@6
 
-      - name: Install xml2 from github (for devel only \#296)
-        if: matrix.config.os == 'macOS-latest' && needs.R-CMD-check-bioc.outputs.rversion == 'devel'
-        run: Rscript -e "remotes::install_github('r-lib/xml2')"
-
       - name: Query dependencies
         run: |
           install.packages('remotes')
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
         shell: Rscript {0}
+
+      - name: Install xml2 from github (for devel only \#296)
+        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'devel'
+        run: Rscript -e "remotes::install_github('r-lib/xml2')"
 
       - name: Cache R packages
         if: runner.os != 'Windows'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,7 +21,6 @@ jobs:
           - {os: windows-latest, r: '3.6'}
           - {os: macOS-latest, r: '3.6'}
           - {os: macOS-latest, r: 'devel'}
-          - {os: ubuntu-16.04, r: '3.4', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.5', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
@@ -41,8 +40,15 @@ jobs:
       - name: Install linux opencv
         if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository ppa:opencpu/opencv
+          sudo add-apt-repository ppa:cran/opencv
           sudo apt install libopencv-dev
+          sudo apt install libavfilter-dev
+
+      - name: Install macos opencv
+        if: runner.os == 'macOS'
+        run: |
+          brew install opencv
+          brew install ffmpeg
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,42 @@
+on:
+  push:
+    branches: master
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: macOS-r-3.6-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: macOS-r-3.6-
+
+      - name: Install dependencies
+        run: |
+          install.packages("remotes")
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_dev("pkgdown")
+        shell: Rscript {0}
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Deploy package
+        run: pkgdown::deploy_to_branch(new_process = FALSE)
+        shell: Rscript {0}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .*
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,8 @@ Authors@R: person(given = "Carl",
            role = c("aut", "cre"),
            email = "c.borstell@let.ru.nl",
            comment = c(ORCID = "0000-0001-7549-4648"))
+URL: https://github.com/borstell/signglossR
+BugReports: https://github.com/borstell/signglossR/issues
 Description: This package is intended to facilitate a visual representation of 
     sign language data by incorporating videos and images alongside written glosses 
     and translations. This includes quick and easy downloads of videos/images from 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # signglossR
 **v1.2.0**
-[![R build status](https://github.com/jonkeane/signglossR/workflows/R-CMD-check/badge.svg)](https://github.com/jonkeane/signglossR/actions)
+[![R build status](https://github.com/borstell/signglossR/workflows/R-CMD-check/badge.svg)](https://github.com/borstell/signglossR/actions)
 
 An R package that facilitates *visual* representation of sign language data
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # signglossR
 **v1.2.0**
+[![R build status](https://github.com/jonkeane/signglossR/workflows/R-CMD-check/badge.svg)](https://github.com/jonkeane/signglossR/actions)
 
 An R package that facilitates *visual* representation of sign language data
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,1 @@
+destination: docs


### PR DESCRIPTION
There aren't tests yet, but `R CMD check` is a good test anyway. The pkgdown site will automatically be built based on the master branch (though is configurable to be only on tags or the like).

I can squash the commits of messing around with getting all of the dependencies on actions working if you would prefer.

You might need to commit one empty commit to the gh-pages branch for github to catch and build them. 

It's possible to configure ghpages to look at the master branch, in the `docs/` directory as well, though I haven't gotten that setup working with GH actions yet.